### PR TITLE
fix a scenario where a consumer tag is re-subscribed, resulting in an exception

### DIFF
--- a/dist/src/activity/Activity.js
+++ b/dist/src/activity/Activity.js
@@ -265,6 +265,7 @@ function Activity(Behaviour, activityDef, context) {
   }
 
   function runDiscard(discardContent = {}) {
+    deactivateRunConsumers();
     executionId = (0, _shared.getUniqueId)(id);
     const content = createMessage({ ...discardContent,
       executionId

--- a/src/activity/Activity.js
+++ b/src/activity/Activity.js
@@ -217,6 +217,8 @@ export default function Activity(Behaviour, activityDef, context) {
   }
 
   function runDiscard(discardContent = {}) {
+    deactivateRunConsumers();
+
     executionId = getUniqueId(id);
     const content = createMessage({...discardContent, executionId});
     broker.publish('run', 'run.discard', content);

--- a/test/feature/signal-feature.js
+++ b/test/feature/signal-feature.js
@@ -326,6 +326,27 @@ Feature('Signals', () => {
       expect(logBook[1]).to.equal('task2');
     });
   });
+
+  Scenario('When a task is discarded by multiple flows', () => {
+    let definition;
+
+    Given('a process', async () => {
+      const source = factory.resource('consumer_error.bpmn');
+      const context = await testHelpers.context(source);
+
+      definition = Definition(context);
+    });
+
+    let wait;
+    When('definition is run', () => {
+      wait = definition.getActivityById('Task_1tomcsq').waitFor('wait');
+      definition.run();
+    });
+
+    Then('manual task executes and waits', () => {
+      return wait;
+    });
+  });
 });
 
 async function prepareSource() {

--- a/test/resources/consumer_error.bpmn
+++ b/test/resources/consumer_error.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0gb2asv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.0">
+  <bpmn:process id="Process_1e62o0s" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>SequenceFlow_1dbu5gr</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0mjqgw6">
+      <bpmn:incoming>SequenceFlow_0l74gai</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0l74gai" sourceRef="Task_1tomcsq" targetRef="EndEvent_0mjqgw6" />
+    <bpmn:manualTask id="Task_1tomcsq" name="Notify escalated">
+      <bpmn:incoming>SequenceFlow_1r57ppx</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_10eqs8z</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1t54x7o</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0l74gai</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1dbu5gr" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1ac2697" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_0b7b4st" default="SequenceFlow_1t54x7o">
+      <bpmn:incoming>SequenceFlow_00dkftk</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1r57ppx</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1t54x7o</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1r57ppx" sourceRef="ExclusiveGateway_0b7b4st" targetRef="Task_1tomcsq">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="javascript">false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1ac2697">
+      <bpmn:incoming>SequenceFlow_1dbu5gr</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_00dkftk</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_10eqs8z</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_00dkftk" sourceRef="ExclusiveGateway_1ac2697" targetRef="ExclusiveGateway_0b7b4st">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="javascript">false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_10eqs8z" sourceRef="ExclusiveGateway_1ac2697" targetRef="Task_1tomcsq">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="javascript">true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_1t54x7o" sourceRef="ExclusiveGateway_0b7b4st" targetRef="Task_1tomcsq" />
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
Ran into a process scenario (consumer_error.bpmn in this PR) which produces the following exception: 

```
Unhandled rejection Error: Consumer tag must be unique, _activity-api is occupied
    at validateConsumerTag (/Users/jk/Development/bpmn-runner/node_modules/smqp/dist/src/Broker.js:353:13)
    at subscribe (/Users/jk/Development/bpmn-runner/node_modules/smqp/dist/src/Broker.js:71:41)
    at Object.subscribeTmp (/Users/jk/Development/bpmn-runner/node_modules/smqp/dist/src/Broker.js:79:12)
    at activateRunConsumers (/Users/jk/Development/bpmn-runner/node_modules/bpmn-elements/dist/src/activity/Activity.js:309:12)
```

(Ignore the non-sensical nature of the process, it's just the simplest repro case)

The issue seems to be around the timing of the task being discarded multiple times from the exclusive gateway flow.  The first time the discard occurs, the `_activity-run` consumer is not yet listening, so `run.leave` is processed after `activateRunConsumers` is called, meaning that `_activity-api` ends up being cancelled.

But the second time through, `_activity-run` is still running, so `run.leave` is processed *before* `activateRunConsumers`, leaving `_activity-api` still listening.  When the task later on is finally run, it attempts to listen to the already in-use `_activity-api` consumer tag.

The solution in this PR (not sure it's the best one) is to deactivate the run consumers before publishing the event.  This seems like a safe way to resolve the issue, but I admit I'm a little unclear on the intended states of the various consumers after the activity is discarded.