### PR TITLE
Make dist command in package.json cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "npm run dist",
     "cov:html": "nyc mocha -R dot && nyc report --reporter=html",
     "test:lcov": "nyc mocha -R dot && nyc report --reporter lcov && npm run posttest",
-    "dist": "babel index.js -d dist && rm -rf dist/src && babel src -d dist/src",
+    "dist": "babel index.js -d dist && shx rm -rf dist/src && babel src -d dist/src",
     "test-md": "node scripts/test-markdown ./API.md && node scripts/test-markdown ./docs/Examples.md",
     "toc": "node scripts/generate-api-toc ./API.md,./docs/Examples.md,./docs/Form.md"
   },
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "iso8601-duration": "^1.3.0",
-    "smqp": "^5.0.0"
+    "smqp": "^5.0.0",
+    "shx": "^0.3.3"
   }
 }


### PR DESCRIPTION
Make 'dist' command in package.json cross-platform. Current version is not working on Windows.