### PR TITLE
fix: executionId for activities

### DIFF
--- a/src/activity/Activity.js
+++ b/src/activity/Activity.js
@@ -174,7 +174,7 @@ export default function Activity(Behaviour, activityDef, context) {
       type,
       ...(name ? {name} : undefined),
       ...(status ? {status} : undefined),
-      parent: cloneParent(parent),
+      parent: cloneParent({...override.parent, ...parent}),
     };
 
     const flags = {isEnd, isStart, isSubProcess, isMultiInstance, isForCompensation, attachedTo, isTransaction};


### PR DESCRIPTION
Hello!
Where is a headache to get parent's executionId by activity in some cases. For example if you will try something like:
`
const activity = execution.definitions[0].getActivityById('activityId');
console.log(activity.parent.executionId);
`
The result is undefined;

And activity gotten by subscription has a valid executionId:
`
    listener.on('activity.start', activity => console.log(activity.content.parent.executionId));
`

I investigated few places where it could be hidden and fix it. I am not sure if it's a correct but it did a job.
What do think?